### PR TITLE
fix random_string number attribute deprecation warning

### DIFF
--- a/iam-roles.tf
+++ b/iam-roles.tf
@@ -28,7 +28,7 @@ data "aws_iam_policy_document" "event_trust" {
 # Generate a random string to add it to the name of the Target Group
 resource "random_string" "iam_suffix" {
   length      = 12
-  number      = true
+  numeric     = true
   min_numeric = 12
 }
 


### PR DESCRIPTION
Just a deprecation fix for `random_string` moving from `number` to `numeric` for that attribute.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
- [x] I have read the CONTRIBUTING.md doc.
- [x] I have added necessary documentation (if appropriate).
- [x] Any dependent changes have been merged and published in downstream modules.
