### PR TITLE
replaced cloudwatch events with eventbridge scheduler-schedule

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -51,7 +51,7 @@ jobs:
     name: Minimum version check
     runs-on: ubuntu-latest
     container:
-      image: hashicorp/terraform:0.12.0
+      image: hashicorp/terraform:1.0.0
     steps:
       - uses: actions/checkout@master
       - name: Validate Code
@@ -59,6 +59,6 @@ jobs:
           AWS_REGION: 'us-east-1'
           TF_WARN_OUTPUT_ERRORS: 1
         run: |
-          sed -i -e 's/>=/=/' -e 's/ \(\d\+\.\d\+\)"/ \1.0"/' versions.tf
+          sed -i -e 's/>=/=/' -e 's/ \(\d\+\.\d\+\)"/ \1.5"/' versions.tf
           terraform init
-          terraform validate -var "region=${AWS_REGION}" -var "vpc_id=vpc-123456" -var "subnets=[\"subnet-12345a\"]" -var "workers_ami_id=ami-123456" -var "cluster_ingress_cidrs=[]" -var "cluster_name=test_cluster"
+          terraform validate

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 This is a module to create a schedule to shut down or start a Relational database service (RDS).
 
 The following resources will be created:
- - AWS Cloudwatch event rule - Delivers a real-time stream of system events that shut down or start the RDS.
+ - AWS Eventbridge event rule - Delivers a real-time stream of system events that shut down or start the RDS.
  - Identity Access Management (IAM) that create a service role for Systems Manager Automation
 
 Notes:
@@ -42,6 +42,7 @@ Aurora DB clusters can't be started or stopped under certain conditions:
 | cron\_stop | Cron expression to define when to trigger a stop of the DB | `any` | n/a | yes |
 | enable | n/a | `bool` | `true` | no |
 | identifier | RDS instance or Aurora Cluster identifier for schedule | `any` | n/a | yes |
+| schedule\_timezone | Timezone used in stop start scheduling cronjob | `any` | n/a | yes |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Aurora DB clusters can't be started or stopped under certain conditions:
 | cron\_stop | Cron expression to define when to trigger a stop of the DB | `any` | n/a | yes |
 | enable | n/a | `bool` | `true` | no |
 | identifier | RDS instance or Aurora Cluster identifier for schedule | `any` | n/a | yes |
-| schedule\_timezone | Timezone used in stop start scheduling cronjob | `any` | n/a | yes |
+| schedule\_timezone | Timezone used in scheduling cronjob | `any` | n/a | yes |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Aurora DB clusters can't be started or stopped under certain conditions:
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.0 |
+| terraform | >= 1.0.0 |
 
 ## Providers
 

--- a/_variables.tf
+++ b/_variables.tf
@@ -18,3 +18,7 @@ variable "cron_start" {
 variable "enable" {
   default = true
 }
+
+variable "schedule_timezone" {
+  description = "Timezone used in scheduling cronjob"
+}

--- a/events.tf
+++ b/events.tf
@@ -1,91 +1,121 @@
-resource "aws_cloudwatch_event_rule" "rds_stop" {
-  count               = var.enable ? 1 : 0
-  name                = "rds-scheduler-${var.identifier}-stop"
-  description         = "Stops RDS instance on a schedule"
-  schedule_expression = "cron(${var.cron_stop})"
+resource "aws_scheduler_schedule" "rds_stop" {
+  count       = var.enable && !var.aurora_cluster ? 1 : 0
+  name        = "rds-scheduler-${var.identifier}-stop"
+  description = "Stops RDS instance on a schedule"
+  group_name  = "default"
+
+  schedule_expression          = "cron(${var.cron_stop})"
+  schedule_expression_timezone = var.schedule_timezone
+
+  flexible_time_window {
+    mode = "OFF"
+  }
+
+  target {
+    arn      = "arn:aws:ssm:${data.aws_region.current.name}::automation-definition/AWS-StopRdsInstance:$DEFAULT"
+    role_arn = aws_iam_role.event[0].arn
+    input = jsonencode(
+      {
+        AutomationAssumeRole = [
+          aws_iam_role.ssm_automation[0].arn,
+        ]
+        InstanceId = [
+          var.identifier,
+        ]
+      }
+    )
+  }
 }
 
-resource "aws_cloudwatch_event_target" "rds_stop" {
-  count = var.enable && !var.aurora_cluster ? 1 : 0
-  arn   = "arn:aws:ssm:${data.aws_region.current.name}::automation-definition/AWS-StopRdsInstance:$DEFAULT"
-  input = jsonencode(
-    {
-      AutomationAssumeRole = [
-        aws_iam_role.ssm_automation[0].arn,
-      ]
-      InstanceId = [
-        var.identifier,
-      ]
-    }
-  )
-  role_arn  = aws_iam_role.event[0].arn
-  rule      = aws_cloudwatch_event_rule.rds_stop[0].name
-  target_id = "rds-scheduler-${var.identifier}-stop"
+resource "aws_scheduler_schedule" "rds_start" {
+  count       = var.enable && !var.aurora_cluster ? 1 : 0
+  name        = "rds-scheduler-${var.identifier}-start"
+  description = "Starts RDS instance on a schedule"
+  group_name  = "default"
+
+  schedule_expression          = "cron(${var.cron_start})"
+  schedule_expression_timezone = var.schedule_timezone
+
+  flexible_time_window {
+    mode = "OFF"
+  }
+
+  target {
+    arn      = "arn:aws:ssm:${data.aws_region.current.name}::automation-definition/AWS-StartRdsInstance:$DEFAULT"
+    role_arn = aws_iam_role.event[0].arn
+    input = jsonencode(
+      {
+        AutomationAssumeRole = [
+          aws_iam_role.ssm_automation[0].arn,
+        ]
+        InstanceId = [
+          var.identifier,
+        ]
+      }
+    )
+  }
 }
 
-resource "aws_cloudwatch_event_rule" "rds_start" {
-  count               = var.enable ? 1 : 0
-  name                = "rds-scheduler-${var.identifier}-start"
-  description         = "Starts RDS instance on a schedule"
-  schedule_expression = "cron(${var.cron_start})"
+resource "aws_scheduler_schedule" "aurora_stop" {
+  count       = var.enable && !var.aurora_cluster ? 1 : 0
+  name        = "rds-scheduler-${var.identifier}-stop"
+  description = "Stops Aurora instance on a schedule"
+  group_name  = "default"
+
+  schedule_expression          = "cron(${var.cron_stop})"
+  schedule_expression_timezone = var.schedule_timezone
+
+  flexible_time_window {
+    mode = "OFF"
+  }
+
+  target {
+    arn      = "arn:aws:ssm:${data.aws_region.current.name}::automation-definition/AWS-StartStopAuroraCluster:$DEFAULT"
+    role_arn = aws_iam_role.event[0].arn
+    input = jsonencode(
+      {
+        AutomationAssumeRole = [
+          aws_iam_role.ssm_automation[0].arn,
+        ]
+        ClusterName = [
+          var.identifier,
+        ]
+        Action = [
+          "Stop",
+        ]
+      }
+    )
+  }
 }
 
-resource "aws_cloudwatch_event_target" "rds_start" {
-  count = var.enable && !var.aurora_cluster ? 1 : 0
-  arn   = "arn:aws:ssm:${data.aws_region.current.name}::automation-definition/AWS-StartRdsInstance:$DEFAULT"
-  input = jsonencode(
-    {
-      AutomationAssumeRole = [
-        aws_iam_role.ssm_automation[0].arn,
-      ]
-      InstanceId = [
-        var.identifier,
-      ]
-    }
-  )
-  role_arn  = aws_iam_role.event[0].arn
-  rule      = aws_cloudwatch_event_rule.rds_start[0].name
-  target_id = "rds-scheduler-${var.identifier}-start"
-}
+resource "aws_scheduler_schedule" "aurora_start" {
+  count       = var.enable && !var.aurora_cluster ? 1 : 0
+  name        = "rds-scheduler-${var.identifier}-start"
+  description = "Starts Aurora instance on a schedule"
+  group_name  = "default"
 
-resource "aws_cloudwatch_event_target" "aurora_stop" {
-  count = var.enable && var.aurora_cluster ? 1 : 0
-  arn   = "arn:aws:ssm:${data.aws_region.current.name}::automation-definition/AWS-StartStopAuroraCluster:$DEFAULT"
-  input = jsonencode(
-    {
-      AutomationAssumeRole = [
-        aws_iam_role.ssm_automation[0].arn,
-      ]
-      ClusterName = [
-        var.identifier,
-      ]
-      Action = [
-        "Stop",
-      ]
-    }
-  )
-  role_arn  = aws_iam_role.event[0].arn
-  rule      = aws_cloudwatch_event_rule.rds_stop[0].name
-  target_id = "rds-scheduler-${var.identifier}-stop"
-}
+  schedule_expression          = "cron(${var.cron_stop})"
+  schedule_expression_timezone = var.schedule_timezone
 
-resource "aws_cloudwatch_event_target" "aurora_start" {
-  count = var.enable && var.aurora_cluster ? 1 : 0
-  arn   = "arn:aws:ssm:${data.aws_region.current.name}::automation-definition/AWS-StartStopAuroraCluster:$DEFAULT"
-  input = jsonencode(
-    {
-      AutomationAssumeRole = [
-        aws_iam_role.ssm_automation[0].arn,
-      ]
-      ClusterName = [
-        var.identifier,
-      ]
-      Action = [
-        "Start",
-      ]
-    }
-  )
-  role_arn  = aws_iam_role.event[0].arn
-  rule      = aws_cloudwatch_event_rule.rds_start[0].name
-  target_id = "rds-scheduler-${var.identifier}-start"
+  flexible_time_window {
+    mode = "OFF"
+  }
+
+  target {
+    arn      = "arn:aws:ssm:${data.aws_region.current.name}::automation-definition/AWS-StartStopAuroraCluster:$DEFAULT"
+    role_arn = aws_iam_role.event[0].arn
+    input = jsonencode(
+      {
+        AutomationAssumeRole = [
+          aws_iam_role.ssm_automation[0].arn,
+        ]
+        ClusterName = [
+          var.identifier,
+        ]
+        Action = [
+          "Start",
+        ]
+      }
+    )
+  }
 }

--- a/iam-roles.tf
+++ b/iam-roles.tf
@@ -5,7 +5,7 @@ data "aws_iam_policy_document" "event" {
     actions   = ["sts:AssumeRole"]
     resources = ["*"]
     principals {
-      type = "Service"
+      type        = "Service"
       identifiers = ["scheduler.amazonaws.com"]
     }
   }
@@ -31,7 +31,7 @@ data "aws_iam_policy_document" "event_trust" {
 # Generate a random string to add it to the name of the Target Group
 resource "random_string" "iam_suffix" {
   length      = 12
-  numeric      = true
+  numeric     = true
   min_numeric = 12
 }
 

--- a/iam-roles.tf
+++ b/iam-roles.tf
@@ -1,10 +1,13 @@
-
 data "aws_iam_policy_document" "event" {
   count = var.enable ? 1 : 0
   statement {
     effect    = "Allow"
-    actions   = ["ssm:StartAutomationExecution"]
+    actions   = ["sts:AssumeRole"]
     resources = ["*"]
+    principals {
+      type = "Service"
+      identifiers = ["scheduler.amazonaws.com"]
+    }
   }
   statement {
     effect    = "Allow"
@@ -28,7 +31,7 @@ data "aws_iam_policy_document" "event_trust" {
 # Generate a random string to add it to the name of the Target Group
 resource "random_string" "iam_suffix" {
   length      = 12
-  number      = true
+  numeric      = true
   min_numeric = 12
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = ">= 0.12.0"
+  required_version = ">= 1.0.0"
 }


### PR DESCRIPTION
Amazon EventBridge Scheduler automatically adjusts your schedule for daylight saving time. When time shifts forward in the Spring, if a cron expression falls on a non-existent date, your schedule invocation is skipped. When time shifts backwards in the Fall, your schedule runs only once and does not repeat its invocation. The following invocations occur normally at the specified date and time.
This change updated cloudwatch_events to eventbridge scheduler_schedule

## Types of changes

What types of changes does your code introduce to <repo_name>?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I have read the CONTRIBUTING.md doc.
- [X] I have added necessary documentation (if appropriate).
- [X] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...